### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python3 new-user-info-spider.py"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # B站3亿用户信息爬虫（mid号，昵称，性别，关注，粉丝，等级）
 ## 声明
+[![Run on Repl.it](https://repl.it/badge/github/zhang0peter/bilibili-user-information-spider)](https://repl.it/github/zhang0peter/bilibili-user-information-spider)
+
 * 代码、教程均为本人原创，且仅限于学习交流，请勿用于任何商业用途！   
 
 ********


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@zhang0peter/bilibili-user-information-spider).